### PR TITLE
Fix documentation of key name for specifiying map parent element

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ Pinpoint accepts a JavaScript object for configuration.
 
 option              | type     | default                                    | description
 ------------------- | -------- | ------------------------------------------ | ------------------
-element             | string   | "#map-el"                                  | CSS selector for map parent element.
+el                  | string   | "#map-el"                                  | CSS selector for map parent element.
 aspect-ratio        | string   | (required)                                 | The shape of the map: "wide" (3x2), "square" (1x1), or "tall" (5x6)
 lat                 | number   | (required)                                 | Latitude for map centre.
 lon                 | number   | (required)                                 | Longitude for map centre.


### PR DESCRIPTION
The option for setting the CSS selector for the map parent element is listed as `element`. However, using this throws the error `Uncaught TypeError: Cannot set property 'innerHTML' of null` with references to lines 19 and 70. I'm not exactly sure why `element` doesn't work, but using `el` instead does work. I'm suggesting updating the documentation to reflect that `el` should be the key name used to specify the map parent element.
